### PR TITLE
解压后多余字节错误修改

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.26)
+project(HuffmanCompressCPro)
+
+set(CMAKE_CXX_STANDARD 17)
+#set(CMAKE_EXE_LINKER_FLAGS "-static")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
+add_executable(HuffmanCompressCPro main.cpp
+        SqList.h
+        Compress.cpp
+        Compress.h
+        Dictionary.cpp
+        Dictionary.h
+        Huffman.cpp
+        Huffman.h
+        CharCount.cpp
+        CharCount.h
+        HuffmanTree.cpp
+        HuffmanTree.h
+        EntryInFile.cpp
+        EntryInFile.h
+        CodeBuffer.cpp
+        CodeBuffer.h
+)

--- a/CodeBuffer.cpp
+++ b/CodeBuffer.cpp
@@ -4,120 +4,120 @@
 
 #include "CodeBuffer.h"
 
-CodeBuffer::CodeBuffer(std::fstream& file, Dictionary& dict):file(file),dict(dict){}
-CodeBuffer::CodeBuffer(std::fstream &file, Dictionary &dict, int validbits):file(file),dict(dict),validbits(validbits){
-    savedseekg=file.tellg();
-    file.seekg(0,std::ios::end);
-    filelength=file.tellg();
-    file.seekg(savedseekg,std::ios::beg);
+CodeBuffer::CodeBuffer(std::fstream& file, Dictionary& dict) :file(file), dict(dict) {}
+CodeBuffer::CodeBuffer(std::fstream& file, Dictionary& dict, int validbits) :file(file), dict(dict), validbits(validbits) {
+	savedseekg = file.tellg();
+	file.seekg(0, std::ios::end);
+	filelength = file.tellg();
+	file.seekg(savedseekg, std::ios::beg);
 }
 Status CodeBuffer::write(const std::string& strbin) {
-    if(!file.is_open())
-        return FILE_OPEN_ERROR;
-    if(strbin.length()+strbuf.length()<=8){//小于一个char的长度的时候不写入
-        strbuf.append(strbin);
-    }else{//大于一个char的长度时，多次写入直到小于8
-        //如果strbuf>=8，先连续写入，直到小于8
-        strbuf+=strbin;
-        while(strbuf.length()>8){
-            io = strbuf2byte();
-            file.write(&io, 1);
-            strbuf = strbuf.substr(8,strbuf.length()-8);
-        }
+	if (!file.is_open())
+		return CB_FILE_OPEN_ERROR;
+	if (strbin.length() + strbuf.length() <= 8) {//小于一个char的长度的时候不写入
+		strbuf.append(strbin);
+	}
+	else {//大于一个char的长度时，多次写入直到小于8
+		//如果strbuf>=8，先连续写入，直到小于8
+		strbuf += strbin;
+		while (strbuf.length() > 8) {
+			io = strbuf2byte();
+			file.write(&io, 1);
+			strbuf = strbuf.substr(8, strbuf.length() - 8);
+		}
 
-    }
-    return 0;
+	}
+	return 0;
 }
 
-char CodeBuffer::strbuf2byte() const{
-    char byte;
-    byte=byte & 0b00000000;
-    for(int i=0;i<8;i++){
-        byte=byte<<1;
-        if(strbuf[i]=='1'){
-            byte=byte | 0b00000001;
-        }
-    }
-    return byte;
+char CodeBuffer::strbuf2byte() const {
+	char byte;
+	byte = byte & 0b00000000;
+	for (int i = 0; i < 8; i++) {
+		byte = byte << 1;
+		if (strbuf[i] == '1') {
+			byte = byte | 0b00000001;
+		}
+	}
+	return byte;
 }
 
-std::string CodeBuffer::byte2str(char byte) const{
-    std::string str;
-    for(char i=0;i<8;i++){
-        if((byte & 0b00000001) == 0b00000001){
-            str='1'+str;
-        }else if((byte & 0b00000001) == 0b00000000){
-            str='0'+str;
-        }
-        byte=byte>>1;
-    }
-    return str;
+std::string CodeBuffer::byte2str(char byte) const {
+	std::string str;
+	for (char i = 0; i < 8; i++) {
+		if ((byte & 0b00000001) == 0b00000001) {
+			str = '1' + str;
+		}
+		else if ((byte & 0b00000001) == 0b00000000) {
+			str = '0' + str;
+		}
+		byte = byte >> 1;
+	}
+	return str;
 }
 
 void CodeBuffer::fillAndWrite() {
-    std::string complement;
-    for(int i=strbuf.length();i<8;i++){
-        complement.push_back('0');
-    }
-    complement.push_back('0');
-    write(complement);
+	std::string complement;
+	for (int i = strbuf.length(); i < 8; i++) {
+		complement.push_back('0');
+	}
+	complement.push_back('0');
+	write(complement);
 }
 
 Status CodeBuffer::read(char& byte) {
-    //函数每次输出一个翻译出来的字节
-    char readbuf;
-    if(savedseekg<filelength){
-        //不涉及validbits
-        //如果strbuf耗尽，就读入
-        if(strbuf.empty() || strpos==strbuf.length()){
-            file.read(&readbuf,1);
-            strbuf=byte2str(readbuf);
-            strpos=0;
-            savedseekg++;
-        }
-        //进行树查找，直到找到，找到后记录数据并返回
-        Status result;
-        do{
-            result=dict.treeSearch(strbuf[strpos],byte);
-            if(strpos<strbuf.length()-1){
-                strpos++;
-            }else{
-                file.read(&readbuf,1);
-                strbuf= byte2str(readbuf);
-                strpos=0;
-                savedseekg++;
-            }
-        }while(result!=NODE_FOUND);
-        return 0;
-    }else if(savedseekg==filelength){
+	//函数每次输出一个翻译出来的字节
+	char readbuf;
+	if (savedseekg < filelength) {
+		//不涉及validbits
+		//如果strbuf耗尽，就读入
+		if (strbuf.empty() || strpos == strbuf.length()) {
+			file.read(&readbuf, 1);
+			if (savedseekg == filelength - 1 && strpos == strbuf.length()) {
+				strbuf = byte2str(readbuf).substr(0, validbits);
+			}
+			else {
+				strbuf = byte2str(readbuf);
+			}
+			strpos = 0;
+			savedseekg++;
+		}
+		//进行树查找，直到找到，找到后记录数据并返回
+		Status result;
+		do {
+			result = dict.treeSearch(strbuf[strpos], byte);
+			if (strpos < strbuf.length()) {
+				strpos++;
+			}
+			else {
+				file.read(&readbuf, 1);
+				if (savedseekg == filelength - 1 && strpos == strbuf.length()) {
+					strbuf = byte2str(readbuf).substr(0, validbits);
+				}
+				else {
+					strbuf = byte2str(readbuf);
+				}
+				strpos = 0;
 
-        savedseekg++;
-        //涉及最后一个字节的validbits
-        //进行读入并截取substr，拼接到strbuf
-        file.read(&readbuf,1);
-        strbuf+=byte2str(readbuf).substr(0,validbits);
-        //进行树查找，直到找到，找到后记录数据并返回
-        Status result;
-        do{
-            result=dict.treeSearch(strbuf[strpos],byte);
-            if(strpos<strbuf.length()-1){
-                strpos++;
-            }
-        }while(result!=NODE_FOUND);
-        return 0;
-    }else if(savedseekg>filelength){
-        Status result;
-        do{
-            result=dict.treeSearch(strbuf[strpos],byte);
-            if(strpos<=strbuf.length()-1){
-                strpos++;
-            }else{
-                return CB_EOF;
-            }
-        }while(result!=NODE_FOUND);
-        return 0;
-    }
-    return CB_EOF;
+				savedseekg++;
+			}
+		} while (result != NODE_FOUND);
+		return 0;
+	}
+	else if (savedseekg >= filelength) {
+		Status result;
+		do {
+			result = dict.treeSearch(strbuf[strpos], byte);
+			if (strpos <= strbuf.length() - 1) {
+				strpos++;
+			}
+			else {
+				return CB_EOF;
+			}
+		} while (result != NODE_FOUND);
+		return 0;
+	}
+	return CB_EOF;
 }
 
 

--- a/CodeBuffer.h
+++ b/CodeBuffer.h
@@ -9,7 +9,7 @@
 #include <fstream>
 #include "Dictionary.h"
 
-#define FILE_OPEN_ERROR -1
+#define CB_FILE_OPEN_ERROR -1
 #define CB_EOF 1
 
 class CodeBuffer {

--- a/Compress.cpp
+++ b/Compress.cpp
@@ -181,7 +181,7 @@ Status Compress::writeHead(std::fstream &writefile, const int validbits, const i
 
     writefile.write(&modBits,1);
     writefile.write((char*)&entryLength,sizeof(int));
-
+    
     for(int i=0;i<entryLength;i++){
         writefile.write(&eif[i].byte,1);
         char bits=eif[i].getBits()+CHAR_MIN-1;
@@ -285,6 +285,7 @@ void Compress::evaluate(const std::string& readfilepath,const std::string& write
     readfilelength=readfile.tellg();
     writefile.seekg(0,std::ios::end);
     writefilelength=writefile.tellg();
+    std::cout<<"readfilepath:"<<readfilepath<<std::endl<<"writefilepath:"<<writefilepath<<std::endl;
     std::cout<<writefilelength<<"/"<<readfilelength<<std::endl;
     std::cout<<"Compress Rate:"<<1.0*writefilelength/readfilelength*100<<"%"<<std::endl;
 }

--- a/Huffman.cpp
+++ b/Huffman.cpp
@@ -99,5 +99,7 @@ void Huffman::postTraversal(const HuffmanTree *rootp,std::string*& codes,const i
     }
     postTraversal(rootp->lchild, codes, length);
     postTraversal(rootp->rchild, codes, length);
-    code.value.pop_back();
+    if (rootp->parent != nullptr) {
+        code.value.pop_back();
+    }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,34 +1,69 @@
 #include <iostream>
+#ifdef __MINGW32__
+#include <unistd.h>
+#else
+#ifdef _MSC_VER
+#include <io.h>
+#include <process.h>
+#endif
+#endif
+#include <filesystem>
 #include "Compress.h"
-#include "SqList.h"
-int main(int argc,char *argv[]) {
-//    std::string mode=argv[1];
-//    std::string readfilepath=argv[2];
-//    std::string writefilepath=argv[3];
-//    std::string destfilepath=argv[4];
-    //用参数或者其他形式输入两个地址
-    std::string readfilepath=R"(C:\E\cpp\HuffmanCompressCPro\assets\Pic.bmp.huf.huf.huf.huf)";
-    std::string writefilepath=R"(C:\E\cpp\HuffmanCompressCPro\assets\Pic.bmp.huf.huf.huf.huf.huf)";
-    std::string destfilepath=R"(C:\E\cpp\HuffmanCompressCPro\assets\Pic.bmp.huf.huf.dest.huf)";
-//    std::string readfilepath=R"(C:\E\cpp\HuffmanCompressCPro\assets\test.mp4)";
-//    std::string writefilepath=R"(C:\E\cpp\HuffmanCompressCPro\assets\test.mp4.huf)";
-//    std::string destfilepath=R"(C:\E\cpp\HuffmanCompressCPro\assets\test.dest.mp4)";
-    //使用Compress.compress(readfilepath,writefilepath)压缩
-    Compress c;
-    Status compressResult=c.compress(readfilepath,writefilepath);
-    if(compressResult==0){
-        std::cout<<"Compress Success!"<<std::endl;
-    }else{
-        std::cout<<"ErrorCode:"<<compressResult;
-    }
 
-    Status decompressResult=c.decompress(writefilepath,destfilepath);
-    if(compressResult==0){
-        std::cout<<"Decompress Success!"<<std::endl;
-    }else{
-        std::cout<<"ErrorCode:"<<decompressResult;
-    }
+void showhelp() {
+	std::filesystem::path currentpath = std::filesystem::current_path();
+	std::cout << "current directory:" << currentpath << std::endl;
+	std::cout << "usage: HuffmanCompressCPro.exe <mode> <source-file-path> <dest-file-path>" << std::endl;
+	std::cout << "mode: c compress, d decompress" << std::endl;
+	std::cout << "example1: HuffmanCompressCPro.exe c file.txt file.txt.huf" << std::endl;
+	std::cout << "example2: HuffmanCompressCPro.exe d file.txt.huf file.dest.txt" << std::endl;
+}
+
+int main(int argc, char* argv[]) {
+	if (argc == 4) {
+		Compress c;
+		std::filesystem::path currentpath = std::filesystem::current_path();
+
+		std::string mode = argv[1];
+		std::string readfilepath = argv[2];
+		std::string writefilepath = argv[3];
+		std::filesystem::path readpath(readfilepath);
+		if (readpath.is_relative()) {
+			readpath = currentpath / readpath;
+		}
+		std::filesystem::path writepath(writefilepath);
+		if (writepath.is_relative()) {
+			writepath = currentpath / writepath;
+		}
+		if (mode == "c") {
 
 
-    return 0;
+			Status compressResult = c.compress(readpath.string(), writepath.string());
+			if (compressResult == 0) {
+				std::cout << "Compress Success!" << std::endl;
+			}
+			else {
+				std::cout << "ErrorCode:" << compressResult;
+			}
+		}
+		else if (mode == "d") {
+
+
+			Status decompressResult = c.decompress(readfilepath, writefilepath);
+			if (decompressResult == 0) {
+				std::cout << "Decompress Success!" << std::endl;
+			}
+			else {
+				std::cout << "ErrorCode:" << decompressResult;
+			}
+		}
+		else {
+			showhelp();
+		}
+	}
+	else {
+		showhelp();
+	}
+
+	return 0;
 }


### PR DESCRIPTION
1.初步完成对解压后文件有多余字节错误的修改，后面可能需要稍微重构一下代码，使之更清晰。
2.同时修改了之前没有注意到的Huffman中的102行的pop_back()在根节点也会调用，导致对空字符串pop_back的错误。